### PR TITLE
-Bclose originally was installed as an dependency and left uncommented

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -8,7 +8,7 @@
 
    Plugin 'VundleVim/Vundle.vim'                        " Keep Plugin between vundle#begin/end.
    Plugin 'tpope/vim-fugitive'                          " Access to git repo commands
-   Plugin 'rbgrouleff/bclose.vim'
+   Plugin 'rbgrouleff/bclose.vim'                       " buffer delete not closing window
    Plugin 'scrooloose/nerdtree'                         " Nerdtree
    Plugin 'git://git.wincent.com/command-t.git'         " File fuzzy finder
    Plugin 'romgrk/doom-one.vim'                         " Doom theme
@@ -43,6 +43,7 @@ let mapleader=" "           " mapped leader to <space>
 " this lets you visualy select and move lines with <shift>
 xnoremap K :move '<-2<CR>gv-gv
 xnoremap J :move '>+1<CR>gv-gv
+map <Leader>bd :Bclose<CR>	      " Kills buffer not window
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => General Settings
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -66,8 +67,8 @@ let g:rehash256 = 1
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " The lightline.vim theme
 let g:lightline = {
-      \ 'colorscheme': 'darcula',
-      \ }
+	  \ 'colorscheme': 'darcula',
+	  \ }
 
 " Always show statusline
 set laststatus=2
@@ -159,7 +160,7 @@ set fillchars+=vert:\
 " => VimWiki
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 let g:vimwiki_list = [{'path': '~/vimwiki/',
-                      \ 'syntax': 'markdown', 'ext': '.md'}]
+					  \ 'syntax': 'markdown', 'ext': '.md'}]
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Vim-Instant-Markdown


### PR DESCRIPTION
-Read the git to construct a worthy comment
-Figured out what it did exactly.
-Realised by adding a keybinding it could solve a real want of mine
-the keybinding will allow me to close vim-wiki with out closing vim
-the git didn't tell you the exact command just the parts
-I assembled the command simply by duplicating a simaler command
-Took it for a test .... worked well enough to add it here
-The next two changes are stricty fommatting tab instead of space