### PR TITLE
- had trouble with previous plugin for markdown preview

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -164,12 +164,14 @@ let g:vimwiki_list = [{'path': '~/vimwiki/',
 					  \ 'syntax': 'markdown', 'ext': '.md'}]
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" => Vim-Instant-Markdown
+" => Markdown-Preview
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-let g:instant_markdown_autostart = 0         " Turns off auto preview
-let g:instant_markdown_browser = "surf"      " Uses surf for preview
-map <Leader>md :InstantMarkdownPreview<CR>   " Previews .md file
-map <Leader>ms :InstantMarkdownStop<CR>      " Kills the preview
+let g:mkdp_auto_start = 0                    " Turns off auto preview
+" specify browser to open preview page       " default= ''
+let g:mkdp_browser = 'surf'                  " Uses surf for preview
+nmap <Leader>mk <Plug>MarkdownPreview        " Previews .md files
+nmap <Leader>nm <Plug>MarkdownPreviewStop    " Kills the preview
+nmap <Leader>mp <Plug>MarkdownPreviewToggle  " Preview toggle
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Other Stuff


### PR DESCRIPTION
- got rid of plugin but left the keybindings
- installed new plugin, old keybinding would not work
- Reading the plugin doc. and looked at the previous keybindings
- I created these. from the two
- seem to work well enough