### PR TITLE
Keybindings redux

### DIFF
--- a/.vimrc_git
+++ b/.vimrc_git
@@ -42,18 +42,21 @@ filetype plugin indent on    " required
 
          " Put your non-Plugin stuff after this line
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" => Key-bindings
+" => Key-bindings *note- leave right uncommeted,seen as command
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-let mapleader="/"                     " mapped leader to </>
-  " move vertically by visual line (don't skip wrapped lines)
-nmap k gk
-nmap j gj
-nmap <leader>w :w!<cr>		          " fast saving
-nnoremap Q :Bclose<CR>                " should kill buffer
-	" visualy select & move lines with <shift>
+" mapped leader to <space>
+let mapleader=" "                     
+" move vertically by visual line (don't skip wrapped lines)
+nnoremap k gk
+nnoremap j gj
+noremap <Up> gk
+noremap <Down> gj
+" open command edit window everytime
+nnoremap : q:i
+nnoremap / q/i
+" visualy select & move lines with <shift>
 xnoremap K :move '<-2<CR>gv-gv
 xnoremap J :move '>+1<CR>gv-gv
-
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Fast editing and reloading of vimrc configs
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
 - Mapped leader back to <space>,still indecisive on this
 - Was just as of late that I find out this little titbit
 - DON'T put comments on the right hand side of a map con-fig
 - And I quote:
 "An important thing to note, make sure you don't put any comments
 on the right hand side of a remap. They will be interpreted as commands
 for the remap as opposed to comments."
 - So fixed this
 - The other thing that I was made aware of, is the whole
 "Non-recursive" mapping. Still confused as to when to use it and when not.
 - So I change some to see what if any effect it will have.
 - Try changing all of them didn't work for the split Keybindings.
 - Added the arrow keybindings as I find myself using them in insert mode
 - Added a binding that will open "command edit" window ever time.
 - This allows me to see my history reuse or edit a command rather retype.
 - This will also save from making a bunch of keybindings if I don't have to.
 - Will have to revisit to add my bclose keybinding.
 - Figure I'd move it to editing section below.
 - Last clean up empty line.